### PR TITLE
Use IsEqual for object comparison in CollectionEquals

### DIFF
--- a/src/Constraints/CollectionEquals.php
+++ b/src/Constraints/CollectionEquals.php
@@ -5,8 +5,10 @@ namespace Soyhuce\Testing\Constraints;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use SebastianBergmann\Comparator\ComparisonFailure;
+use function is_object;
 
 class CollectionEquals extends Constraint
 {
@@ -53,7 +55,11 @@ class CollectionEquals extends Constraint
         }
 
         foreach ($this->value as $key => $value) {
-            $constraint = $value instanceof Model ? new IsModel($value) : new IsIdentical($value);
+            $constraint = match (true) {
+                $value instanceof Model => new IsModel($value),
+                is_object($value) => new IsEqual($value),
+                default => new IsIdentical($value),
+            };
 
             if (!$constraint->evaluate($other->get($key), returnResult: true)) {
                 return false;

--- a/tests/Unit/CollectionEqualsTest.php
+++ b/tests/Unit/CollectionEqualsTest.php
@@ -2,6 +2,7 @@
 
 namespace Soyhuce\Testing\Tests\Unit;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Collection;
@@ -26,6 +27,10 @@ class CollectionEqualsTest extends TestCase
             [new Collection(['a' => 1, 'b' => 2, 'c' => 3]), new Collection(['a' => 1, 'b' => 2, 'c' => 3])],
             [['a' => 1, 'b' => 2, 'c' => 3], new Collection(['a' => 1, 'b' => 2, 'c' => 3])],
             [new Collection([new User(['id' => 1, 'name' => 'John'])]),  new Collection([new User(['id' => 1, 'name' => 'Peter'])])],
+            [
+                new Collection([CarbonImmutable::create(2022, 5, 11)]),
+                new Collection([CarbonImmutable::createFromFormat('!Y-m-d', '2022-05-11')]),
+            ],
         ];
     }
 


### PR DESCRIPTION
This allows to make the two collections 
```
$c1 = new Collection([CarbonImmutable::create(2022, 5, 11)]);
$c2 = new Collection([CarbonImmutable::createFromFormat('!Y-m-d', '2022-05-11')]);
```
considered equal