### PR TITLE
Allow multiple messages for TestValidationResult::failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,15 @@ $this->createRequest(CreateUserRequest::class)
 $this->createRequest(CreateUserRequest::class)
     ->validate([
         'name' => null,
-        'email' => 'john doe',
+        'email' => 12,
     ])
     //->assertFails() We can check that the validation fails without defining the fields nor error messages
     ->assertFails([
         'name' => 'The name field is required.',
-        'email' => 'The email must be a valid email address.',
+        'email' => [
+            'The email must be a string.',
+            'The email must be a valid email address.',
+        ]
     ]);
 
 $this->createRequest(CreateUserRequest::class)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,12 @@ parameters:
 			path: src/FormRequest/TestFormRequest.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with arguments string, Illuminate\\\\Support\\\\Collection\\<string, array\\<string\\>\\> and non\\-empty\\-string will always evaluate to false\\.$#"
+			message: "#^Parameter \\#1 \\$key of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects int\\|string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: src/FormRequest/TestValidationResult.php
+
+		-
+			message: "#^Part \\$attribute \\(array\\<int, string\\>\\|string\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: src/FormRequest/TestValidationResult.php
 
@@ -14,6 +19,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$transformation of method Soyhuce\\\\Testing\\\\Match\\\\ValueMatcher\\:\\:match\\(\\) expects callable\\(\\)\\: mixed, array\\<0\\|1\\|string, mixed\\> given\\.$#"
 			count: 1
 			path: src/Match/Matcher.php
+
+		-
+			message: "#^Call to an undefined method Soyhuce\\\\Testing\\\\TestResponse\\\\DataAssertions\\:\\:assertJsonPathMissing\\(\\)\\.$#"
+			count: 2
+			path: src/TestResponse/DataAssertions.php
 
 		-
 			message: "#^Method Soyhuce\\\\Testing\\\\TestResponse\\\\DataAssertions\\:\\:assertDataPath\\(\\) invoked with 2 parameters, 0 required\\.$#"

--- a/tests/Unit/TestFormRequestTest.php
+++ b/tests/Unit/TestFormRequestTest.php
@@ -94,6 +94,25 @@ class TestFormRequestTest extends TestCase
      * @test
      * @covers ::validate
      */
+    public function theFormRequestIsInvalidWithArrayOfMessages(): void
+    {
+        $this->createRequest(CreateUserRequest::class)
+            ->validate([
+                'name' => 'John Doe',
+                'email' => 12,
+            ])
+            ->assertFails([
+                'email' => [
+                    'The email must be a string.',
+                    'The email must be a valid email address.',
+                ],
+            ]);
+    }
+
+    /**
+     * @test
+     * @covers ::validate
+     */
     public function theFormRequestVerifiesTheMessage(): void
     {
         $this->expectException(AssertionFailedError::class);
@@ -105,6 +124,29 @@ class TestFormRequestTest extends TestCase
             ])
             ->assertFails([
                 'name' => 'foo',
+            ]);
+    }
+
+    /**
+     * @test
+     * @covers ::validate
+     */
+    public function theFormRequestVerifiesAnArrayOfMessages(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageMatches(
+            '/Failed to find a validation error in the response for key and message: \'email\' => \'The email must be a string.\'/'
+        );
+
+        $this->createRequest(CreateUserRequest::class)
+            ->validate([
+                'name' => 'John Doe',
+                'email' => 'john doe',
+            ])
+            ->assertFails([
+                'email' => [
+                    'The email must be a string.',
+                ],
             ]);
     }
 


### PR DESCRIPTION
Support multiple validation errors :

```php
$this->createRequest(CreateUserRequest::class)
    ->validate([
        'name' => null,
        'email' => 12,
    ])
    ->assertFails([
        'name' => 'The name field is required.',
        'email' => [
            'The email must be a string.',
            'The email must be a valid email address.',
        ]
    ]);