### PR TITLE
Add MocksActions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
-            testbench: 7.*
+            testbench: ^7.9
           - laravel: 10.*
             testbench: 8.*
         exclude:

--- a/README.md
+++ b/README.md
@@ -302,6 +302,49 @@ $this->mock(CreateUser::class)
     ->once();
 ```
 
+### ActionMock
+
+The trait `MocksActions` provides a `mockAction` method to simply mock an action. By convention, an action is a class with a `execute` method.
+
+Under the hood, it uses `Mockery::mock`.
+
+It allows to easily define your action's expectations. Instead of  
+```php
+$user = User::factory()->createOne();
+
+$this->mock(DeleteUser::class)
+    ->shouldReceive('execute')
+    ->withArgs(function(User $executed) use ($user) {
+        $this->assertIsModel($user, $executed);
+        
+        return true;
+    })
+    ->once();
+```
+you can write
+```php
+$user = User::factory()->createOne();
+
+$this->mockAction(DeleteUser::class)
+   ->with($user);
+```
+
+You can also define the return value and capture it to use it in your test.
+
+```php
+$this->mockAction(CreateUser::class)
+    ->with(new UserData(email: 'john.doe@email.com', password: 'password'))
+    ->returns(fn() => User::factory()->createOne())
+    ->in($user);
+
+$this->postJson('register', ['email' => 'john.doe@email.com', 'password' => 'password'])
+    ->assertCreated()
+    ->assertJson([
+        'id' => $user->id,
+        'name' => $user->name,
+        'email' => $user->email,
+    ]);
+```
 
 ### Helpers
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "friendsofphp/php-cs-fixer": "^3.6",
         "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0 || ^8.0",
+        "orchestra/testbench": "^7.9 || ^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-phpunit": "^1.0",
+        "spatie/data-transfer-object": "^3.9"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,36 @@ parameters:
 			path: src/Match/Matcher.php
 
 		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\:\\:andReturnUsing\\(\\)\\.$#"
+			count: 2
+			path: src/Mock/PendingActionMock.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\:\\:never\\(\\)\\.$#"
+			count: 1
+			path: src/Mock/PendingActionMock.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\:\\:withArgs\\(\\)\\.$#"
+			count: 1
+			path: src/Mock/PendingActionMock.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\:\\:zeroOrMoreTimes\\(\\)\\.$#"
+			count: 1
+			path: src/Mock/PendingActionMock.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:andReturnUsing\\(\\)\\.$#"
+			count: 1
+			path: src/Mock/PendingActionMock.php
+
+		-
+			message: "#^Property Soyhuce\\\\Testing\\\\Mock\\\\PendingActionMock\\:\\:\\$mock \\(Mockery\\\\MockInterface\\) does not accept Mockery\\\\LegacyMockInterface\\.$#"
+			count: 1
+			path: src/Mock/PendingActionMock.php
+
+		-
 			message: "#^Access to an undefined property Soyhuce\\\\Testing\\\\TestResponse\\\\ContractAssertions\\:\\:\\$baseResponse\\.$#"
 			count: 1
 			path: src/TestResponse/ContractAssertions.php

--- a/src/Concerns/MocksActions.php
+++ b/src/Concerns/MocksActions.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Testing\Concerns;
+
+use Soyhuce\Testing\Mock\PendingActionMock;
+
+trait MocksActions
+{
+    /**
+     * @param class-string $action
+     */
+    protected function mockAction(string $action): PendingActionMock
+    {
+        return new PendingActionMock($action);
+    }
+}

--- a/src/Match/Matcher.php
+++ b/src/Match/Matcher.php
@@ -22,7 +22,9 @@ class Matcher
                     $value = self::isModel($value);
                 } elseif ($value instanceof Collection) {
                     $value = self::collectionEquals($value);
-                }
+                } elseif (class_exists(\Spatie\DataTransferObject\DataTransferObject::class) && $value instanceof \Spatie\DataTransferObject\DataTransferObject) {
+                    $value = self::of($value::class)->properties(...$value->all())->toClosure();
+                } // TODO : drop support for Spatie DTO
 
                 if (is_callable($value)) {
                     $result = $value($args[$key]);

--- a/src/Mock/PendingActionMock.php
+++ b/src/Mock/PendingActionMock.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Testing\Mock;
+
+use Closure;
+use Mockery;
+use Mockery\ExpectationInterface;
+use Mockery\MockInterface;
+use Soyhuce\Testing\Match\Matcher;
+use Soyhuce\Testing\Match\ValueMatcher;
+use function Soyhuce\Testing\capture;
+
+class PendingActionMock
+{
+    private Closure $returnsUsing;
+
+    private MockInterface $mock;
+
+    private ExpectationInterface $mockedMethod;
+
+    /**
+     * @param class-string $action
+     */
+    public function __construct(
+        string $action,
+    ) {
+        $this->returnsUsing = fn () => null;
+
+        $this->mock = Mockery::mock($action);
+        $this->mockedMethod = $this->mock
+            ->shouldReceive('execute')
+            ->andReturnUsing($this->returnsUsing)
+            ->once();
+
+        app()->instance($action, $this->mock);
+    }
+
+    /**
+     * @param array<int, mixed> $arguments
+     */
+    public function with(mixed ...$arguments): self
+    {
+        $matcher = Matcher::make(...array_map($this->toMatcher(...), $arguments));
+
+        $this->mockedMethod->withArgs($matcher);
+
+        return $this;
+    }
+
+    private function toMatcher(mixed $argument): mixed
+    {
+        if ($argument instanceof Closure || $argument instanceof ValueMatcher) {
+            return $argument;
+        }
+
+        return Matcher::make($argument);
+    }
+
+    public function returns(Closure $returnsUsing): self
+    {
+        $this->returnsUsing = $returnsUsing;
+        $this->mockedMethod->andReturnUsing($returnsUsing);
+
+        return $this;
+    }
+
+    public function in(mixed &$in): self
+    {
+        $this->mockedMethod->andReturnUsing(capture($in, $this->returnsUsing));
+
+        return $this;
+    }
+
+    public function neverCalled(): self
+    {
+        $this->mockedMethod->never();
+
+        return $this;
+    }
+
+    public function anyTimes(): self
+    {
+        $this->mockedMethod->zeroOrMoreTimes();
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/BasicAction.php
+++ b/tests/Fixtures/BasicAction.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Testing\Tests\Fixtures;
+
+class BasicAction
+{
+    public function execute(int $value): int
+    {
+        return $value;
+    }
+}

--- a/tests/Unit/MocksActionTest.php
+++ b/tests/Unit/MocksActionTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Testing\Tests\Unit;
+
+use Mockery;
+use Mockery\Exception\InvalidCountException;
+use PHPUnit\Framework\AssertionFailedError;
+use Soyhuce\Testing\Concerns\MocksActions;
+use Soyhuce\Testing\Tests\Fixtures\BasicAction;
+use Soyhuce\Testing\Tests\TestCase;
+
+/**
+ * @covers \Soyhuce\Testing\Concerns\MocksActions
+ */
+class MocksActionTest extends TestCase
+{
+    use MocksActions;
+
+    /**
+     * @test
+     */
+    public function theActionCanBeMocked(): void
+    {
+        $this->mockAction(BasicAction::class)
+            ->with(2)
+            ->returns(fn () => 4)
+            ->in($result);
+
+        $value = app(BasicAction::class)->execute(2);
+
+        $this->assertEquals(4, $value);
+        $this->assertEquals(4, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function receivesTheArgumentInReturnsCallback(): void
+    {
+        $this->mockAction(BasicAction::class)
+            ->with(2)
+            ->returns(fn (int $value) => $value + 3)
+            ->in($result);
+
+        $value = app(BasicAction::class)->execute(2);
+
+        $this->assertEquals(5, $value);
+        $this->assertEquals(5, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function theActionFailsIfNotCalled(): void
+    {
+        $this->mockAction(BasicAction::class)
+            ->with(2)
+            ->returns(fn () => 4)
+            ->in($result);
+
+        $this->expectException(InvalidCountException::class);
+
+        Mockery::close();
+    }
+
+    /**
+     * @test
+     */
+    public function theActionFailsIfCalledWithOtherArgument(): void
+    {
+        $this->mockAction(BasicAction::class)
+            ->with(2)
+            ->anyTimes();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that 3 is identical to 2.');
+
+        app(BasicAction::class)->execute(3);
+    }
+
+    /**
+     * @test
+     */
+    public function theActionCanBeNeverCalled(): void
+    {
+        $this->mockAction(BasicAction::class)
+            ->neverCalled();
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function theActionFailsIfCalledButDeclaredNeverCalled(): void
+    {
+        $this->mockAction(BasicAction::class)
+            ->returns(fn () => 4)
+            ->neverCalled();
+
+        app(BasicAction::class)->execute(2);
+
+        $this->expectException(InvalidCountException::class);
+
+        Mockery::close();
+    }
+}


### PR DESCRIPTION
The trait `MocksActions` provides a `mockAction` method to simply mock an action. By convention, an action is a class with a `execute` method.

Under the hood, it uses `Mockery::mock`.

It allows to easily define your action's expectations. Instead of  
```php
$user = User::factory()->createOne();

$this->mock(DeleteUser::class)
    ->shouldReceive('execute')
    ->withArgs(function(User $executed) use ($user) {
        $this->assertIsModel($user, $executed);
        
        return true;
    })
    ->once();
```
you can write
```php
$user = User::factory()->createOne();

$this->mockAction(DeleteUser::class)
   ->with($user);
```

You can also define the return value and capture it to use it in your test.

```php
$this->mockAction(CreateUser::class)
    ->with(new UserData(email: 'john.doe@email.com', password: 'password'))
    ->returns(fn() => User::factory()->createOne())
    ->in($user);

$this->postJson('register', ['email' => 'john.doe@email.com', 'password' => 'password'])
    ->assertCreated()
    ->assertJson([
        'id' => $user->id,
        'name' => $user->name,
        'email' => $user->email,
    ]);
```

Fixes #17 