### PR TITLE
Remove support for spatie/data-transfer-object, improve support for spatie/laravel-data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "spatie/data-transfer-object": "^3.9"
+        "spatie/laravel-data": "^3.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/Concerns/LaravelAssertions.php
+++ b/src/Concerns/LaravelAssertions.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert;
 use Soyhuce\Testing\Constraints\CollectionEquals;
+use Soyhuce\Testing\Constraints\DataEquals;
 use Soyhuce\Testing\Constraints\IsModel;
 use function is_array;
 
@@ -29,6 +30,13 @@ trait LaravelAssertions
         }
 
         $constraint = new CollectionEquals($expected);
+
+        Assert::assertThat($actual, $constraint, $message);
+    }
+
+    public static function assertDataEquals(\Spatie\LaravelData\Data $expected, mixed $actual, string $message = ''): void
+    {
+        $constraint = new DataEquals($expected);
 
         Assert::assertThat($actual, $constraint, $message);
     }

--- a/src/Constraints/CollectionEquals.php
+++ b/src/Constraints/CollectionEquals.php
@@ -57,6 +57,7 @@ class CollectionEquals extends Constraint
         foreach ($this->value as $key => $value) {
             $constraint = match (true) {
                 $value instanceof Model => new IsModel($value),
+                class_exists(\Spatie\LaravelData\Data::class) && $value instanceof \Spatie\LaravelData\Data => new DataEquals($value),
                 is_object($value) => new IsEqual($value),
                 default => new IsIdentical($value),
             };

--- a/src/Constraints/DataEquals.php
+++ b/src/Constraints/DataEquals.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Testing\Constraints;
+
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Constraint\Constraint;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use Spatie\LaravelData\Data;
+
+class DataEquals extends Constraint
+{
+    public function __construct(
+        protected Data $value,
+    ) {
+    }
+
+    public function evaluate(mixed $other, string $description = '', bool $returnResult = false): ?bool
+    {
+        $success = $this->matches($other);
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if ($success) {
+            return null;
+        }
+
+        $failure = $other instanceof Data
+            ? new ComparisonFailure(
+                $this->value,
+                $other,
+                $this->exporter()->export($this->value),
+                $this->exporter()->export($other)
+            )
+            : null;
+
+        $this->fail($other, $description, $failure);
+    }
+
+    protected function matches(mixed $other): bool
+    {
+        if (!$other instanceof Data) {
+            return false;
+        }
+
+        return (new CollectionEquals(Collection::make($this->value->all())))
+            ->matches(Collection::make($other->all()));
+    }
+
+    protected function failureDescription(mixed $other): string
+    {
+        return $this->exporter()->export($other) . ' ' . $this->toString();
+    }
+
+    public function toString(): string
+    {
+        return 'is same data that ' . $this->exporter()->export($this->value);
+    }
+}

--- a/src/Match/Matcher.php
+++ b/src/Match/Matcher.php
@@ -22,9 +22,9 @@ class Matcher
                     $value = self::isModel($value);
                 } elseif ($value instanceof Collection) {
                     $value = self::collectionEquals($value);
-                } elseif (class_exists(\Spatie\DataTransferObject\DataTransferObject::class) && $value instanceof \Spatie\DataTransferObject\DataTransferObject) {
-                    $value = self::of($value::class)->properties(...$value->all())->toClosure();
-                } // TODO : drop support for Spatie DTO
+                } elseif (class_exists(\Spatie\LaravelData\Data::class) && $value instanceof \Spatie\LaravelData\Data) {
+                    $value = self::dataEquals($value);
+                }
 
                 if (is_callable($value)) {
                     $result = $value($args[$key]);
@@ -59,6 +59,15 @@ class Matcher
     {
         return function (mixed $actual) use ($expected) {
             LaravelAssert::assertCollectionEquals($expected, $actual);
+
+            return true;
+        };
+    }
+
+    public static function dataEquals(\Spatie\LaravelData\Data $expected): Closure
+    {
+        return function (mixed $actual) use ($expected) {
+            LaravelAssert::assertDataEquals($expected, $actual);
 
             return true;
         };

--- a/tests/Fixtures/SimpleData.php
+++ b/tests/Fixtures/SimpleData.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Soyhuce\Testing\Tests\Fixtures;
+
+use Spatie\LaravelData\Data;
+
+class SimpleData extends Data
+{
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Soyhuce\Testing\Tests;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Soyhuce\Testing\TestingServiceProvider;
+use Spatie\LaravelData\LaravelDataServiceProvider;
 
 /**
  * @coversNothing
@@ -24,6 +25,7 @@ class TestCase extends Orchestra
     {
         return [
             TestingServiceProvider::class,
+            LaravelDataServiceProvider::class,
         ];
     }
 }

--- a/tests/Unit/MatcherTest.php
+++ b/tests/Unit/MatcherTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\ExpectationFailedException;
 use Soyhuce\Testing\Match\Matcher;
+use Soyhuce\Testing\Tests\Fixtures\SimpleData;
 use Soyhuce\Testing\Tests\TestCase;
 
 /**
@@ -127,6 +128,49 @@ class MatcherTest extends TestCase
 
         $collection = new Collection([1, 2]);
         Matcher::collectionEquals([1, 2, 3])($collection);
+    }
+
+    /**
+     * @test
+     * @covers ::make
+     */
+    public function matcherMatchesData(): void
+    {
+        $expected = new SimpleData('foo', 1);
+        $value = SimpleData::from(['name' => 'foo', 'age' => 1]);
+        $value->getPartialTrees();
+
+        $result = Matcher::make($expected)($value);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     * @covers ::make
+     */
+    public function matcherFailsMatchingData(): void
+    {
+        $expected = new SimpleData('foo', 1);
+        $value = SimpleData::from(['name' => 'bar', 'age' => 12]);
+
+        $this->expectException(ExpectationFailedException::class);
+        Matcher::make($expected)($value);
+    }
+
+    /**
+     * @test
+     * @covers ::make
+     */
+    public function matcherMatchesCollectionOfData(): void
+    {
+        $expected = new SimpleData('foo', 1);
+        $value = SimpleData::from(['name' => 'foo', 'age' => 1]);
+        $value->getPartialTrees();
+
+        $result = Matcher::make(collect([$expected]))(collect([$value]));
+
+        $this->assertTrue($result);
     }
 
     /**


### PR DESCRIPTION
The comparison between 2 datas is done on their proper attributes, not the ones internal of the package