### PR TITLE
Fix collection equals canonicalizing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,8 @@ jobs:
         exclude:
           - php: 8.4
             stability: prefer-lowest
+          - phpunit: ^10.0
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - PU${{ matrix.phpunit }}- ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/src/Concerns/LaravelAssertions.php
+++ b/src/Concerns/LaravelAssertions.php
@@ -52,10 +52,12 @@ trait LaravelAssertions
             $expected = new Collection($expected);
         }
 
-        $expected = Arr::isList($expected->all()) ? $expected->sort()->values() : $expected->sort();
+        $sort = fn (mixed $item) => $item instanceof Model ? $item->getKey() : $item;
+
+        $expected = Arr::isList($expected->all()) ? $expected->sortBy($sort)->values() : $expected->sortBy($sort);
 
         if ($actual instanceof Collection) {
-            $actual = Arr::isList($actual->all()) ? $actual->sort()->values() : $actual->sort();
+            $actual = Arr::isList($actual->all()) ? $actual->sortBy($sort)->values() : $actual->sortBy($sort);
         }
 
         $constraint = new CollectionEquals($expected);

--- a/tests/Unit/CollectionEqualsTest.php
+++ b/tests/Unit/CollectionEqualsTest.php
@@ -59,6 +59,10 @@ class CollectionEqualsTest extends TestCase
                 new Collection([new User(['id' => 2, 'name' => 'Jack']), new User(['id' => 1, 'name' => 'Peter'])]),
             ],
             [
+                new Collection([new User(['name' => 'John', 'id' => 1]), new User(['name' => 'Jack', 'id' => 2])]),
+                new Collection([new User(['id' => 2, 'name' => 'Jack']), new User(['id' => 1, 'name' => 'Peter'])]),
+            ],
+            [
                 new Collection([
                     'John' => new User(['id' => 1, 'name' => 'John']),
                     'Jack' => new User(['id' => 2, 'name' => 'Jack']),


### PR DESCRIPTION
When comparing collections of fresh models with a collection of retrieved models from database, the attributes can be in different order.
The sorting are different and the conparison fails 

```php
$users = User::factory(5)->create();
LaravelAssert::assertCollectionEqualsCanonicalizing($users, $users->fresh()->shuffle()); // fails
```
Sorting by the model key solves the issue